### PR TITLE
fix:recently edited files change ignore bug

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -642,7 +642,7 @@ export class Core {
 
     on("didChangeActiveTextEditor", async ({ data: { filepath } }) => {
       try {
-        const ignore = shouldIgnore(filepath, this.ide);
+        const ignore = await shouldIgnore(filepath, this.ide);
         if (!ignore) {
           recentlyEditedFilesCache.set(filepath, filepath);
         }


### PR DESCRIPTION
function shouldIgnore return promise，if dont await，nothing can set in recentlyEditedFilesCache

## Description

[ What changed? Feel free to be brief. ]

## Checklist

- [] The relevant docs, if any, have been updated or created
- [] The relevant tests, if any, have been updated or created

## Screenshots

[ For visual changes, include screenshots. Screen recordings are particularly helpful, and appreciated! ]

## Testing instructions

[ For new or modified features, provide step-by-step testing instructions to validate the intended behavior of the change, including any relevant tests to run. ]
